### PR TITLE
localeの設定ミスへの対応

### DIFF
--- a/AppBase.py
+++ b/AppBase.py
@@ -33,6 +33,12 @@ class MaiｎBase(wx.App):
 		#各種初期設定
 		self.InitLogger()
 		self.LoadSettings()
+		# localeは「ja_JP」のような形式。設定ファイルの定義ミスにより「_」ではなく「-」を使っていたため、必要に応じて最初に設定ファイルを書き換える。
+		locale_old = self.config["general"]["locale"]
+		if "-" in locale_old:
+			locale_new = locale_old.replace("-", "_")
+			self.log.warn("Fixed locale setting: %s -> %s" % (locale_old, locale_new))
+			self.config["general"]["locale"] = locale_new
 		try:
 			if self.config["general"]["locale"]!=None:
 				locale.setlocale(locale.LC_TIME,self.config["general"]["locale"])

--- a/DefaultSettings.py
+++ b/DefaultSettings.py
@@ -10,7 +10,7 @@ class DefaultSettings:
 		config["general"]={
 			"language": "ja-JP",
 			"fileVersion": "101",
-			"locale": "ja-JP",
+			"locale": "ja_JP",
 			"autoHide": False,
 			"minimizeOnExit": True,
 		}


### PR DESCRIPTION
これまで、設定ファイルの`locale`の値を`ja-JP`のような形式にしていましたが、これでは、`datetime.datetime.strptime()`でエラーになります。
正しくは、`ja_JP`のように、「_」で区切った文字列です。

そこで、以下の修正をしました。

1. `defaultSettings.py`の`locale`を変更
2. 設定ファイルの内容が間違っていても正しく動作するよう、`appBase.py`で必要に応じて書き換えるように修正
