### PR TITLE
fixed #52 windows11のタスクトレイアイコンのキーボード操作ができない問題の修正

### DIFF
--- a/views/tbIcon.py
+++ b/views/tbIcon.py
@@ -13,6 +13,9 @@ class TaskbarIcon(wx.adv.TaskBarIcon):
 		self.icon = wx.Icon(constants.APP_ICON)
 		self.SetIcon(self.icon, constants.APP_NAME)
 		self.Bind(wx.adv.EVT_TASKBAR_LEFT_DCLICK, self.onDoubleClick)
+		# windows11ではタスクトレイアイコン上でエンターを押下した際の動作が変わったっぽいので下記もダブルクリックと同視する
+		self.Bind(wx.adv.EVT_TASKBAR_LEFT_UP, self.onDoubleClick)
+
 
 	def CreatePopupMenu(self):
 		bm = BaseMenu("mainView")


### PR DESCRIPTION
windows11においてタスクトレイのキー操作が変更されていると思われます。
シングルクリックとダブルクリックで挙動の違う他者性アプリにて、エンターキー押下で実行されるのがシングルクリック時の動作となっていました。
ULTRAはダブルクリックイベントしか捕まえていないので、このような結果となったものと思われます。

幸い、現状ダブルクリックとシングルクリックで別々の動作を割り当てるようなことはしていないので、どちらのイベントにおいても機能を実行するよう変更します。
